### PR TITLE
Fix Configuration\Listing\Dao::load() - Exception in RestController::ExecuteAction()

### DIFF
--- a/src/Model/Configuration/Listing/Dao.php
+++ b/src/Model/Configuration/Listing/Dao.php
@@ -38,6 +38,8 @@ class Dao extends Model\Listing\Dao\AbstractDao
             $items[] = Configuration::getById($id);
         }
 
+        $this->model->setData($items);
+
         return $items;
     }
 


### PR DESCRIPTION
Fix issue #207 by ensuring the correct data is set in the Configuration/Listing/Dao::load() method. 
This fix ensures the $listing->current() method used in RestController::ExecuteAction() operates correctly.