### PR TITLE
Single quote namespace containing single backspace

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -12,7 +12,7 @@ elements_process_manager:
         - {username: "tester" , apiKey: "1234"}
         - {username: "tester2" , apiKey: "344"}
     configurationMigrationsDirectory: "%kernel.project_dir%/src/Migrations"
-    configurationMigrationsNamespace: "App\Migrations"
+    configurationMigrationsNamespace: 'App\Migrations'
 
 services:
     example:


### PR DESCRIPTION
Either double backspace and double quotes, or single quotes.

`  #message: "The file "/app/config/packages/elements_process_manager.yaml" does not contain valid YAML: Found unknown escape character "\M" at line 11 (near "configurationMigrationsNamespace: "App\Migrations"") in /app/config/packages/elements_process_manager.yaml (which is being imported from "/app/src/Kernel.php")."`