### PR TITLE
sanitize input using escapeshellarg function

### DIFF
--- a/src/Service/CommandsValidator.php
+++ b/src/Service/CommandsValidator.php
@@ -44,17 +44,28 @@ class CommandsValidator
 
     public function validateCommandConfiguration(LazyCommand | Command $command, Configuration $configuration): void
     {
-
         $settings = $configuration->getExecutorSettingsAsArray();
         $values = $settings['values'];
-
+    
         $commandOptions = $values['commandOptions'] ?? '';
-
-        //Todo: check if command options are valid
-        //and throw an error if they are not valid
-
-        //        throw new Exception('Command options are not valid');
-
+    
+        // Validate and sanitize command options
+        if (!$this->areCommandOptionsValid($commandOptions)) {
+            throw new Exception('Command options are not valid');
+        }
+    }
+    
+    private function areCommandOptionsValid(string $commandOptions): bool
+    {
+        // Escape shell arguments to prevent injection
+        $sanitizedOptions = escapeshellarg($commandOptions);
+    
+        // Validate using regex to ensure only allowed characters are present
+        if (preg_match('/^[a-zA-Z0-9\s\-]+$/', $sanitizedOptions)) {
+            return true;
+        }
+    
+        return false;
     }
 
     /**


### PR DESCRIPTION
### Description : 

I have added a sanitization function based on the pre-built PHP function **`escapeshellarg`**. This function will take the **"_Option_"** input and escape all potentially dangerous characters to prevent **OS command injection vulnerabilities**. The sanitization process ensures that any input provided for command options is safe and cannot be used to execute unintended commands on the host machine.

Key changes include:

- Integration of `escapeshellarg` to properly escape shell arguments.
- Additional validation to ensure that the command options contain only allowed characters (letters, numbers, spaces, and hyphens).
- Enhanced security measures to mitigate the risk of command injection by validating and sanitizing user inputs.

These changes aim to improve the overall security of the application by preventing command injection attacks.

### Example : 

**1. Input: `; ls -la #`**
Explanation: This input contains a potentially harmful shell command sequence. The `;` character ends the current command, and `ls -la` lists the directory contents in detail. The `#` character comments out the rest of the command, making it effectively ignored by the shell. Without proper sanitization, this input could be used for command injection, allowing unintended shell commands to execute.

**2. After Escape the option will be like: `'; ls -la #'`**
Explanation: The escapeshellarg function in PHP processes this input to make it safe for use in shell commands. It encloses the entire input within single quotes and escapes any single quotes inside the input to ensure that it is treated as a single, literal argument. If the option containe already ' the output will becomes `''\''; ls -la #'\''` when escaped. This means that instead of executing the `ls -la` command, the entire input is interpreted as a safe, literal string argument.

### Important notes : 
I used two mechanisms to sanitize the input. The first one is the `escapeshellarg` function, and the second one is `preg_match('/^[a-zA-Z0-9\s\-]+$/', $sanitizedOptions)`. For any business requirement, we can remove the `preg_match` function. However, I require having them both to ensure that if `escapeshellarg` has a bypass in the future, the `preg_match` will catch and stop the injection.

I would appreciate it if one of the maintainers could review this update before it gets merged.